### PR TITLE
Update to Java 8 compatible extractor v0.22.7 and fix API changes

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -13,8 +13,8 @@ android {
         resValue "string", "app_name", "NewPipe"
         minSdkVersion 19
         targetSdkVersion 29
-        versionCode 993
-        versionName "0.22.3.2"
+        versionCode 994
+        versionName "0.22.3.3"
 
         multiDexEnabled true
 
@@ -175,7 +175,9 @@ dependencies {
         exclude module: 'support-annotations'
     }
 
-    implementation 'com.github.TeamNewPipe:NewPipeExtractor:eb07d70a2ce03bee3cc74fc33b2e4173e1c21436'
+    // v0.22.5+ requires Java 11
+    //implementation 'com.github.TeamNewPipe:NewPipeExtractor:eb07d70a2ce03bee3cc74fc33b2e4173e1c21436'
+    implementation 'com.github.Jtfk:NewPipeExtractor-j8:0.22.7-j8'
 
     implementation "com.github.TeamNewPipe:nanojson:1d9e1aea9049fc9f85e68b43ba39fe7be1c1f751"
     implementation "org.jsoup:jsoup:1.13.1"

--- a/app/src/main/java/org/schabi/newpipe/info_list/holder/CommentsMiniInfoItemHolder.java
+++ b/app/src/main/java/org/schabi/newpipe/info_list/holder/CommentsMiniInfoItemHolder.java
@@ -95,7 +95,7 @@ public class CommentsMiniInfoItemHolder extends InfoItemHolder {
         streamUrl = item.getUrl();
 
         itemContentView.setLines(COMMENT_DEFAULT_LINES);
-        commentText = item.getCommentText();
+        commentText = item.getCommentText().getContent();
         itemContentView.setText(commentText);
         itemContentView.setOnTouchListener(CommentTextOnTouchListener.INSTANCE);
 


### PR DESCRIPTION
<!-- Hey there. Thank you so much for improving NewPipe. Please take a moment to fill out the following suggestion on how to structure this PR description. Having roughly the same layout helps everyone considerably :)-->

#### What is it?
- [x] Bug fix (user facing)
- [ ] Feature (user facing)
- [ ] Code base improvement (dev facing)
- [ ] Meta improvement to the project (dev facing)

#### Description of the changes in your PR
Upstream extractor requires Java 11 to build since v0.22.5.

This updates to a modified version of the extractor (https://github.com/Jtfk/NewPipeExtractor-j8), which is based on v0.22.7 upstream with backports to support Java 8

#### Known Issue
Some YouTube comments will have HTML tags shown unless `https://github.com/TeamNewPipe/NewPipe/pull/9631` is introduced (might be out of scope for this repo).

#### Testing apk
<!-- Ensure that you have your changes on a new branch which has a meaningful name. This name will be used as a suffix for the app ID to allow installing and testing multiple versions of NewPipe. Do NOT name your branches like "patch-0" and "feature-1". For example, if your PR implements a bug fix for comments, an appropriate branch name would be "commentfix". -->
[update-extractor-v0.22.7.zip](https://github.com/XiangRongLin/NewPipe-preuinified/files/12346741/update-extractor-v0.22.7.zip)
(this is a debug build and shall use for testing only)

#### Agreement
- [x] I carefully read the [contribution guidelines](https://github.com/TeamNewPipe/NewPipe/blob/HEAD/.github/CONTRIBUTING.md) and agree to them.
